### PR TITLE
replace `document.createElement("img")` with `new Image()` in load_image_from_img_or_url

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -1563,7 +1563,7 @@ class FlagPatcher {
 		if (something.constructor !== String)
 			return something;
 		return new Promise((resolve, reject) => {
-			const img = document.createElement("img");
+			const img = new Image();
 			img.onload = () => resolve(img);
 			img.onerror = reject;
 			img.src = something;


### PR DESCRIPTION
This adds support for loading flag images by providing a relative path to the file like `media/font/languages/ru_RU.png` thanks to the fact that CCLoader's built-in mod "simplify" hooks into the `Image` constructor here:

https://github.com/CCDirectLink/CCLoader/blob/481f00699cba4cce1d3f3c9712e804081a592e94/assets/mods/simplify/postloadModule.js#L368-L392