### PR TITLE
fix bug in reserve_free_space which caused overwriting of the font

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -1110,8 +1110,10 @@ class FontPatcher {
 			if (rect.height !== multifont.charHeight)
 				console.warn("bad height for", c);
 		};
-		const char_count = multifont.indicesX.length;
-		this.free_space = { x: multifont.indicesX[char_count - 1],
+		const char_count = multifont.widthMap.length;
+		this.free_space = { x: multifont.indicesX[char_count - 1]
+				     + multifont.widthMap[char_count - 1]
+				     + 2,
 				    y: multifont.indicesY[char_count - 1] };
 		this.context.reserve_char
 			= this.reserve_free_space.bind(this, multifont);


### PR DESCRIPTION
Turns out you simply forgot to add width of the last character plus 2 - I copied that from the original implementation of `reserve_free_space`. Also, a name like `this.allocated_space` would be more appropriate instead of `this.free_space` from my understanding of the code.