### PR TITLE
use resource loading functions from the standard library

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -323,7 +323,7 @@ class JSONPatcher {
 		if (cached)
 			return cached;
 
-		const ret = ccmod.resources.loadJSON(thing);
+		const ret = ccmod.resources.plain.loadJSON(ccmod.resources.resolvePathToURL(thing));
 		this.url_cache[thing] = ret;
 		ret.then(() => { delete this.url_cache[thing]; });
 		return ret;

--- a/mod.js
+++ b/mod.js
@@ -323,9 +323,7 @@ class JSONPatcher {
 		if (cached)
 			return cached;
 
-		const ret = fetch(thing).then(resp => (
-			resp.ok ? resp.json() : Promise.reject(resp)
-		));
+		const ret = ccmod.resources.loadJSON(thing);
 		this.url_cache[thing] = ret;
 		ret.then(() => { delete this.url_cache[thing]; });
 		return ret;
@@ -563,8 +561,6 @@ class JSONPatcher {
 	 * This reimplements ccloader v3's localized fields
 	 */
 	patch_ccloader3_mods(json, path, pack) {
-		if (!window.modloader || !window.modloader.loadedMods)
-			return; // not ccloader v3
 		const { from_locale }
 			= this.game_locale_config.get_localedef_sync();
 		const { options } = json.labels;
@@ -585,7 +581,7 @@ class JSONPatcher {
 						  true);
 		};
 
-		window.modloader.loadedMods.forEach((mod, id) => {
+		modloader.loadedMods.forEach((mod, id) => {
 			const modEnabled_id = `modEnabled-${id}`;
 			if (!options[modEnabled_id])
 				return;
@@ -1458,12 +1454,7 @@ class FlagPatcher {
 		// But something instanceof String does not work... Whatever.
 		if (something.constructor !== String)
 			return something;
-		return new Promise((resolve, reject) => {
-			const img = new Image();
-			img.onload = () => resolve(img);
-			img.onerror = reject;
-			img.src = something;
-		});
+		return ccmod.resources.loadImage(something);
 	}
 	async collect_all_flags() {
 		const cls = this.constructor;
@@ -1628,8 +1619,7 @@ if (window.location.search.indexOf("en_LEA") !== -1) { // test
 			}
 			return source;
 		},
-		pre_patch_font: () => (
-			new Promise((resolve) => setTimeout(resolve, 5000))
-		)
+		pre_patch_font: () => ccmod.utils.wait(5000)
+
 	});
 }


### PR DESCRIPTION
**NOTE:** This is a PR to the `v1.x` branch!

1. These functions perform URL rewriting (such as applying asset overrides), which in the past was a side-effect of using XHR and constructing `HTMLImageElement` (i.e. `new Image()`). Byproduct of this is ability to patch translation packs and flags, although I don't see where this could be useful.

2. In case that byproduct ability of translation pack and flag patching is not desired

   ```js
   ccmod.resources.plain.loadJSON(ccmod.resources.resolvePathToURL(path))
   ```
   can be used instead. This combination just performs URL rewriting, but doesn't involve patching logic inside `ccmod.resources.loadJSON`. Also `loadJSON` has the `allowPatching` option, which can be used like

   ```js
   ccmod.resources.loadJSON(path, { allowPatching: false })
   ```

   This doesn't disable behavior which can be potentially added, e.g. Emi wanted to add an ability to generate assets on the fly, though I don't really see the point of disabling patching in the first place apart from potentially a minor speed-up.

3. Note that these functions take asset paths, not generic URLs. This means that the following line in French-CC:

   https://github.com/L-Sherry/French-CC/blob/f17fbacf0f9c2b1b49c366550d5892eef62084fa/mod.js#L260

   Needs to be changed to:

   ```js
   const my_prefix = new URL('./', import.meta.url).pathname;
   ```

4. In case a user of Localize Me needs to load translation packs and the flag with an absolute URL (Why the heck would they do that is an open question. Emi did something similar with their DevModLoader server, but that effectively changed `ig.root`, so all assets were loaded from it, and I made sure this is fully supported by CCLoader 3.) you already provide a way to specify custom functions used for fetching resources.

5. Now that I think about it, is there any reason behind the `url_cache` in `JSONPatcher`? I loaded the game, placed a `console.log` in the `if (cached)` branch and didn't observe any double-fetching.

P.S. It would also be nice if you incremented the version number in the manifest to `1.0.0`. I'm planning to distribute this version with the next crosscode-ru update.