### PR TITLE
Fix crash when a modded locale is set, but the save file doesn't exist or is empty

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -219,8 +219,11 @@ class GameLocaleConfiguration {
 		// added locales.
 		const patch_loaded_globals = function (globals) {
 			const id = index_by_locale(ig.currentLang);
-			if (id !== null)
+			if (id !== null) {
+				if (globals.options === undefined)
+					globals.options = {};
 				globals.options.language = id;
+			}
 			this.parent(globals);
 		};
 		// And we save a 0 if it is an added locale.


### PR DESCRIPTION
The scenario is unlikely under normal conditions, I know, but I observed it multiple times during mod development. CCLoader performs exactly the same check before injecting mod enabled/disabled statuses into the options object.